### PR TITLE
fix deprecation warning for abstract type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: julia
 sudo: false
 os:
   - linux
-#  - osx
+  - osx
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
 julia 0.5
+
+Compat 0.17.0

--- a/src/IPNets.jl
+++ b/src/IPNets.jl
@@ -1,6 +1,8 @@
 __precompile__(true)
 module IPNets
 
+using Compat
+
 import Base: IPAddr, IPv4, IPv6, eltype,
 length, size, endof, minimum, maximum, extrema, isless,
 in, contains, issubset, getindex,
@@ -20,7 +22,7 @@ width(::Type{IPv6}) = UInt8(128)
 ##################################################
 # IPNet
 ##################################################
-abstract IPNet
+@compat abstract type IPNet end
 
 ##################################################
 # Network representations


### PR DESCRIPTION
Gets rid of deprecation warning for `abstract IPNet`:

```
WARNING: deprecated syntax "abstract IPNet".
Use "abstract type IPNet end" instead.
```