### PR TITLE
IPAddr constructor for v4/6 networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,15 @@ julia> size(a)
 (4294967296,)
 ```
 
-Though these examples use the `IPv4Net` type, the `IPv6Net` type is also available with similar behavior.
+Though these examples use the `IPv4Net` type, the `IPv6Net` type is also available with similar behavior:
+```
+julia> IPNet("1.2.3.0/24")
+IPNets.IPv4Net("1.2.3.0/24")
+
+julia> IPNet("2001:1::/64")
+IPNets.IPv6Net("2001:1::/64")
+```
+
 
 ### Known Issues
 - Extrema measurements for `IPNets` representing the entire IPv4 or IPv6 address

--- a/src/IPNets.jl
+++ b/src/IPNets.jl
@@ -22,6 +22,8 @@ width(::Type{IPv6}) = UInt8(128)
 ##################################################
 abstract type IPNet end
 
+IPNet(ipmask::AbstractString) = ':' in ipmask ? IPv6Net(ipmask) : IPv4Net(ipmask)
+
 ##################################################
 # Network representations
 ##################################################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ using Base.Test
         @test eltype(n1) == IPv4
         @test n5[1] == ip41
         @test getindex(n5,1) == ip41
+        @test IPNet("1.2.3.0/24") == n1
     end
 
     # IPv6
@@ -96,5 +97,6 @@ using Base.Test
         @test eltype(o1) == IPv6
         @test o5[1] == ip61
         @test getindex(o5,1) == ip61
+        @test IPNet("2001:1::/64") == o1
     end
 end


### PR DESCRIPTION
Hi,

This is a very small change to add a constructor for `IPAddr` that returns an `IPv4Net` or an `IPv6Net` depending on the input string. 
I found this to be useful when parsing a large amount of network measurement results with different IP versions.

The detection is done as in Julia stdlib:
```julia
# https://github.com/JuliaLang/julia/blob/9d11f62bcb124327831206089967f93020e84200/base/socket.jl#L237-L243
function parse(::Type{IPAddr}, str::AbstractString)
    if ':' in str
        return parse(IPv6, str)
    else
        return parse(IPv4, str)
    end
end
```
