### PR TITLE
Julia v0.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ sudo: false
 os:
   - linux
 #  - osx
-julia:
- - 0.6
- - nightly
 
-matrix:
-  allow_failures:
-    - julia: nightly
+# TODO: Replace with 0.7 once released
+julia:
+ - nightly
 
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
-Compat
+julia 0.7
+Sockets

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
 julia 0.7
-Sockets

--- a/src/IPNets.jl
+++ b/src/IPNets.jl
@@ -1,13 +1,12 @@
 __precompile__(true)
 module IPNets
 
-import Base: eltype,
+import Base: eltype, lastindex,
 length, size, minimum, maximum, extrema, isless,
 in, contains, issubset, getindex,
 show, string, start, next, done
 
-import Compat: AbstractRange, lastindex, something
-import Compat.Sockets: IPAddr, IPv4, IPv6, @ip_str
+import Sockets: IPAddr, IPv4, IPv6, @ip_str
 
 export
     # types

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using IPNets
-using Base.Test
+using Compat.Test
+
+import Compat: lastindex
+import Compat.Sockets: IPAddr, IPv4, IPv6, @ip_str
 
 @testset "IPNets" begin
     ip41 = IPv4("1.2.3.4")
@@ -47,7 +50,7 @@ using Base.Test
         @test endswith(string(display,n5),"(\"1.2.3.4/30\")") == true
         @test size(n5) == (4,)
         @test [x for x in n5] == [ip"1.2.3.4", ip"1.2.3.5", ip"1.2.3.6", ip"1.2.3.7"]
-        @test endof(n5) == 4
+        @test lastindex(n5) == 4
         @test minimum(n5) == ip"1.2.3.4"
         @test maximum(n5) == ip"1.2.3.7"
         @test extrema(n5) == (ip"1.2.3.4",ip"1.2.3.7")
@@ -84,7 +87,7 @@ using Base.Test
         @test endswith(string(display,o5),"(\"2001:1::4/126\")") == true
         @test size(o5) == (4,)
         @test [x for x in o5] == [ip"2001:1::4",ip"2001:1::5",ip"2001:1::6",ip"2001:1::7"]
-        @test endof(o5) == 4
+        @test lastindex(o5) == 4
         @test minimum(o5) == ip"2001:1::4"
         @test maximum(o5) == ip"2001:1::7"
         @test extrema(o5) == (ip"2001:1::4",ip"2001:1::7")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
 using IPNets
-using Compat.Test
-
-import Compat: lastindex
-import Compat.Sockets: IPAddr, IPv4, IPv6, @ip_str
+using Test
+import Sockets: IPAddr, IPv4, IPv6, @ip_str
 
 @testset "IPNets" begin
     ip41 = IPv4("1.2.3.4")


### PR DESCRIPTION
This fixes tests and removes deprecation warnings on Julia v0.7.

I converted the code to the v0.7 syntax and used the [Compat](https://github.com/JuliaLang/Compat.jl) module to keep the code working with older versions.

```
# Before
Test Summary: | Pass  Error  Total
IPNets        |   59      8     67
  IPv4        |   32      5     37
  IPv6        |   27      3     30

# After
Test Summary: | Pass  Total
IPNets        |   67     67
```