### PR TITLE
Ipv4 in ipv6net

### DIFF
--- a/src/IPNets.jl
+++ b/src/IPNets.jl
@@ -126,6 +126,8 @@ Base.show(io::IO, net::T) where T <: IPNet = print(io, T, "(\"", net, "\")")
 
 Base.in(ip::IPv4, network::IPv4Net) = ip.host & network.netmask == network.netaddr
 Base.in(ip::IPv6, network::IPv6Net) = ip.host & network.netmask == network.netaddr
+Base.in(ip::Any,  network::IPv4Net) = false
+Base.in(ip::Any,  network::IPv6Net) = false
 
 # IP Networks are ordered first by starting network address
 # and then by network mask. That is, smaller IP nets (with higher

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,4 +137,19 @@ using IPNets, Test, Sockets
     @test !is_global(ip"::1")
     @test !is_private(ip"2606:4700:4700::1111")
     @test is_global(ip"2606:4700:4700::1111")
+
+    ###############
+    ## Both nets ##
+    ###############
+
+    ip6net1 = IPv6Net("2605:dead:beef:ff00::/64")
+    ip6net2 = IPv6Net("::ffff:0:0/96") # IPv4 addresses encoded as IPv6
+    ip4net  = IPv4Net("192.168.0.0/16")
+
+    @test !(ip"192.168.1.200" in ip6net1)
+    @test !(ip"192.168.1.200" in ip6net2) # *
+    @test !(ip"2606:4700:4700::1111" in ip4net)
+    @test !(ip"::ffff:c0a8:01c8" in ip4net) # *
+    # * If IPv4-mapped addresses are considered equivalent, these tests should
+    # be true, but that requires more code.
 end


### PR DESCRIPTION
Anything other than an IPv4 address in an IPv4Net is now false immediately, and likewise anything other than an IPv6 address in an IPv6Net. Before, it scanned the entire IPNet looking for the thing that's not the same type of address.

This fixes issue #21.

I added four tests, two of which are an IPv4 address, with either the address or the network mapped into IPv6. It's your call whether these should be true or false.